### PR TITLE
Mac: Update binding.gyp to to pickup the new ocsrm lib

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -30,6 +30,11 @@
 				"src/callback-info.c"
 			],
 			"libraries": [ "<(PRODUCT_DIR)/libffi.a" ],
+			"xcode_settings": {
+				"OTHER_LDFLAGS": [
+					'-loctbstack', '-locsrm', '-lconnectivity_abstraction', '-lc_common', '-lcoap'
+				]
+			},
 			"conditions": [
 				[ "'<!(echo $TESTING)'=='true'",
 						{ "defines": [ "TESTING" ] } ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -47,7 +47,7 @@
 			"xcode_settings": {
 				"OTHER_CFLAGS": ['<!(pkg-config --cflags glib-2.0)'],
 				"OTHER_LDFLAGS": [
-					'-loctbstack', '-lconnectivity_abstraction', '-lc_common', '-lcoap'
+					'-loctbstack', '-locsrm', '-lconnectivity_abstraction', '-lc_common', '-lcoap'
 				]
 			}
 		},
@@ -60,7 +60,7 @@
 			"xcode_settings": {
 				"OTHER_CFLAGS": ['<!(pkg-config --cflags glib-2.0)'],
 				"OTHER_LDFLAGS": [
-					'-loctbstack', '-lconnectivity_abstraction', '-lc_common', '-lcoap'
+					'-loctbstack', '-locsrm', '-lconnectivity_abstraction', '-lc_common', '-lcoap'
 				]
 			}
 		},
@@ -73,7 +73,7 @@
 			"xcode_settings": {
 				"OTHER_CFLAGS": ['<!(pkg-config --cflags glib-2.0)'],
 				"OTHER_LDFLAGS": [
-					'-loctbstack', '-lconnectivity_abstraction', '-lc_common', '-lcoap'
+					'-loctbstack', '-locsrm', '-lconnectivity_abstraction', '-lc_common', '-lcoap'
 				]
 			}
 		},
@@ -86,7 +86,7 @@
 			"xcode_settings": {
 				"OTHER_CFLAGS": ['<!(pkg-config --cflags glib-2.0)'],
 				"OTHER_LDFLAGS": [
-					'-loctbstack', '-lconnectivity_abstraction', '-lc_common', '-lcoap'
+					'-loctbstack', '-locsrm', '-lconnectivity_abstraction', '-lc_common', '-lcoap'
 				]
 			}
 		}


### PR DESCRIPTION
Iotivity 0.9.1 seems to bring in new lib which we are handling one-by-one on OSX currently.