### PR TITLE
OicClient: Remove handle when PRESENCE_TRIGGER_DELETE event is received

### DIFF
--- a/lib/OicClient.js
+++ b/lib/OicClient.js
@@ -336,6 +336,13 @@ _.extend( devicePrototype, {
 									delete this._resources[ index ];
 								}
 							}
+							if ( this._handles[ deviceId ] ) {
+								if ( !this._handles[ deviceId ].stale ) {
+									iotivity.OCCancel( this._handles[ deviceId ],
+										iotivity.OCQualityOfService.OC_HIGH_QOS, null, 0 );
+								}
+								delete this._handles[ deviceId ];
+							}
 							break;
 
 						default:


### PR DESCRIPTION
Delete the handle from the list when the presence is disabled and device has been deleted.