### PR TITLE
Parse the test cases results log by json

### DIFF
--- a/tests/getresult.js
+++ b/tests/getresult.js
@@ -1,0 +1,38 @@
+var fs = require( "fs" );
+
+var jsonFilename = require( "path" ).resolve( __dirname, "results.json" );
+
+var date = new Date(),
+    data = "",
+    caseList = [],
+    setList = [],
+    allList = [],
+    test = {},
+    testInfo = {};
+
+exports.getTestResult = function( status, success, failure  ) {
+
+    if ( status.result ) {
+        success = "PASS";
+    } else if ( !status.result ) {
+        failure = "FAIL";
+    }
+
+    testInfo = { "message": (  status.runtime  + ": " + status.message ),
+                 "result": ( status.result ? success : failure ),
+                 "runtime": ( date.toLocaleTimeString() )
+               };
+
+    if ( setList.indexOf( status.name ) > -1 && ( "results" in test ) ) {
+            test.results.push( testInfo );
+            caseList.push( test );
+    } else {
+        setList.push( status.name );
+        test = { "test": status.name, "results": [ testInfo ] };
+        caseList.push( test );
+        allList.push( test );
+    }
+
+    data = JSON.stringify( { "output": allList }, null, 4 );
+    fs.writeFileSync( jsonFilename, data );
+};

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -14,7 +14,8 @@
 
 var success = "\x1b[42;30m✓\x1b[0m",
 	failure = "\x1b[41;30m✗\x1b[0m",
-	QUnit = require( "qunitjs" );
+	QUnit = require( "qunitjs" ),
+	results = require( "./getresult" );
 
 // Right-align runtime in a field that's 10 columns wide
 function formatRuntime( runtime ) {
@@ -51,6 +52,8 @@ QUnit.config.callbacks.testStart.push( function( status ) {
 QUnit.config.callbacks.log.push( function( status ) {
 
 	// Parameters: status: { module, result(t/f), message, actual, expected, testId, runtime }
+
+	results.getTestResult( status, success, failure );
 
 	console.log(
 		( status.result ? success : failure ) +


### PR DESCRIPTION
- Generate a json file to collect the test results.
- Locate easily the failed tests in result file when using the results file
- Quickly generate results to match the specified format that QA required
- JSON dose not need to take up extra workspace.

Signed-off-by: Wang Hongjuan <hongjuan.wang@intel.com>