### PR TITLE
Tests: Assert that JS API objects have all required properties

### DIFF
--- a/tests/assert-to-console.js
+++ b/tests/assert-to-console.js
@@ -38,5 +38,30 @@ module.exports = {
 	die: function( message ) {
 		console.log( JSON.stringify( { teardown: true, message: message, isError: true } ) );
 		process.exit( 1 );
+	},
+
+	// ObjectName: A string describing the object - for example "OicDiscovery"
+	// Object: The object to be examined
+	// Properties: An array of objects containing two properties:
+	//	name: The name of the property which must be present on object
+	//	type: The name of the type the property must have
+	// For example:
+	//   assertProperties( "OicDevice", device, [
+	//	 { name: "name", type: "string" },
+	//	 { name: "uuid", type: "string" },
+	//	 ...
+	//   ] );
+	assertProperties: function( objectName, object, properties ) {
+	  var index;
+	  for ( index in properties ) {
+		this.assert( "ok", properties[ index ].name in object,
+		  objectName + " has " + properties[ index ].name );
+		if ( properties[ index ].type ) {
+			this.assert( "strictEqual", typeof object[ properties[ index ].name ],
+				properties[ index ].type,
+				objectName + "." + properties[ index ].name + " is a " + properties[ index ].type );
+		}
+
+	  }
 	}
 };

--- a/tests/tests/API Device Information/client.js
+++ b/tests/tests/API Device Information/client.js
@@ -16,6 +16,7 @@ var _ = require( "lodash" );
 var utils = require( "../../assert-to-console" );
 var oic = require( "../../../index" )( "client" );
 var uuid = process.argv[ 2 ];
+
 var expectedDeviceInfo = {
 
 	// The uuid field will be set to the deviceId when we know the deviceId
@@ -34,7 +35,7 @@ var expectedPlatformInfo = {
 	supportUrl: "supportUrl:" + uuid
 };
 
-console.log( JSON.stringify( { assertionCount: 4 } ) );
+console.log( JSON.stringify( { assertionCount: 34 } ) );
 
 new Promise( function findTheDeviceId( fulfill, reject ) {
 	var teardown;
@@ -56,6 +57,14 @@ new Promise( function findTheDeviceId( fulfill, reject ) {
 	oic.findResources( { resourcePath: "/a/" + uuid } ).catch( teardown );
 } ).then( function getDeviceInfo( deviceId ) {
 	return oic.getDeviceInfo( deviceId ).then( function assertDeviceInfo( deviceInfo ) {
+		utils.assertProperties( "OicDevice", deviceInfo, [
+			  { name: "uuid", type: "string" },
+			  { name: "url", type: "string" },
+			  { name: "name", type: "string" },
+			  { name: "dataModels", type: "string" },
+			  { name: "coreSpecVersion", type: "string" },
+			  { name: "role", type: "string" }
+			] );
 		utils.assert( "deepEqual", deviceInfo, expectedDeviceInfo,
 			"Client: The retrieved device information is as expected" );
 		return deviceId;
@@ -64,6 +73,17 @@ new Promise( function findTheDeviceId( fulfill, reject ) {
 	return oic.getPlatformInfo( deviceId ).then( function assertPlatformInfo( platformInfo ) {
 
 		// Convert the manufactureDate to a timestamp for unambiguous comparison
+		utils.assertProperties( "OicPlatform", platformInfo, [
+			  { name: "id", type: "string" },
+			  { name: "osVersion", type: "string" },
+			  { name: "model", type: "string" },
+			  { name: "manufacturerName", type: "string" },
+			  { name: "manufacturerUrl", type: "string" },
+			  { name: "manufactureDate", type: "object" },
+			  { name: "platformVersion", type: "string" },
+			  { name: "firmwareVersion", type: "string" },
+			  { name: "supportUrl", type: "string" }
+			] );
 		utils.assert( "deepEqual", _.extend( platformInfo, {
 			manufactureDate: new Date( platformInfo.manufactureDate ).getTime()
 		} ), expectedPlatformInfo, "Client: The retrieved platform information is as expected" );

--- a/tests/tests/API Device Information/server.js
+++ b/tests/tests/API Device Information/server.js
@@ -34,7 +34,10 @@ console.log( JSON.stringify( { assertionCount: 4 } ) );
 
 try {
 	oic.device = _.extend( {}, oic.device, {
-		name: "API Device Info Server " + uuid
+		name: "API Device Info Server " + uuid,
+		role: "Server " + uuid,
+		url: "http://example.com/",
+		dataModels: "dataModels: " + uuid
 	} );
 } catch ( anError ) {
 	theError = anError;

--- a/tests/tests/API OicClient Existing.js
+++ b/tests/tests/API OicClient Existing.js
@@ -1,0 +1,27 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	 http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var utils = require( "../assert-to-console" ),
+	device = require( "../../index" )( "client" );
+
+console.log( JSON.stringify( { assertionCount:8 } ) );
+
+utils.assertProperties( "OicClient", device, [
+	  { name: "create", type: "function" },
+	  { name: "retrieve", type: "function" },
+	  { name: "update", type: "function" },
+	  { name: "delete", type: "function" }
+	] );
+
+process.exit( 0 );

--- a/tests/tests/API OicDiscovery Existing.js
+++ b/tests/tests/API OicDiscovery Existing.js
@@ -1,0 +1,30 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var utils = require( "../assert-to-console" ),
+	device = require( "../../index" )( "client" );
+
+console.log( JSON.stringify( { assertionCount:11 } ) );
+
+utils.assertProperties( "OicDiscovery", device, [
+      { name: "findResources", type: "function" },
+      { name: "getDeviceInfo", type: "function" },
+      { name: "getPlatformInfo", type: "function" },
+      { name: "findDevices", type: "function" },
+      { name: "onresourcefound" },
+      { name: "ondevicefound" },
+      { name: "ondiscoveryerror" }
+    ] );
+
+process.exit( 0 );

--- a/tests/tests/API OicServer Existing.js
+++ b/tests/tests/API OicServer Existing.js
@@ -1,0 +1,34 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var utils = require( "../assert-to-console" ),
+	device = require( "../../index" )( "server" );
+
+console.log( JSON.stringify( { assertionCount: 16 } ) );
+
+utils.assertProperties( "OicServer", device, [
+      { name: "register", type: "function" },
+      { name: "unregister", type: "function" },
+      { name: "notify", type: "function" },
+      { name: "enablePresence", type: "function" },
+      { name: "disablePresence", type: "function" },
+      { name: "onobserverequest" },
+      { name: "onunobserverequest" },
+      { name: "onretrieverequest" },
+      { name: "ondeleterequest" },
+      { name: "onupdaterequest" },
+      { name: "oncreaterequest" }
+    ] );
+
+process.exit( 0 );

--- a/tests/tests/API Presence/client.js
+++ b/tests/tests/API Presence/client.js
@@ -16,7 +16,13 @@ var utils = require( "../../assert-to-console" ),
 	device = require( "../../../index" )( "client" ),
 	uuid = process.argv[ 2 ];
 
-console.log( JSON.stringify( { assertionCount: 8 } ) );
+console.log( JSON.stringify( { assertionCount: 13 } ) );
+
+utils.assertProperties( "OicPresence", device, [
+	  { name: "subscribe", type: "function" },
+	  { name: "unsubscribe", type: "function" },
+	  { name: "ondevicechange" }
+	] );
 
 // Tell the resource's server to perform an operation (either disablePresence or enablePresence)
 // or, if op is undefined, then do not communicate with the server. Either way, wait five seconds


### PR DESCRIPTION
- Add tests to check exists and type for interface OicClient,
  OicDevice, OicDiscovery, OicPlatform, OicPresence and OicServer.

- There are 70 asserts (check points), 64 of them are passed and 6 failed.
  (On Edison with image#[1], failed reason#[2])

[1]:https://download.ostroproject.org/builds/ostro-os/2016-07-04_12-17-07-build-473/images/
[2]:https://github.com/otcshare/iotivity-node/issues/52

Signed-off-by: Bin Miao <bin.miao@intel.com>