### PR TITLE
All: Fix the TypeError exception seen in retrieve method

### DIFF
--- a/lib/OicClient.js
+++ b/lib/OicClient.js
@@ -613,6 +613,11 @@ _.extend( devicePrototype, {
 	},
 
 	retrieve: function( id, queryParameters ) {
+		var resource = this._resources[ id.deviceId + ":" + id.path ];
+		if ( !resource ) {
+			return Promise.reject( new Error( id.path + ": resource not found" ) );
+		}
+
 		return this._oneShotRequest( {
 			prefix: "retrieve",
 			resourceId: _.extend( {}, id, queryParameters ? {
@@ -620,7 +625,6 @@ _.extend( devicePrototype, {
 			} : {} ),
 			method: "OC_REST_GET",
 			createAnswer: function retrieveResourceFromResponse( handle, response ) {
-				var resource = this._resources[ id.deviceId + ":" + id.path ];
 				_.extend( resource.properties,
 					utils.payloadToObject( response.payload.values ) );
 				return resource;


### PR DESCRIPTION
This fixes the TypeError exception when retrieve called before the resource discovery.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>