### PR TITLE
OicServer: Parse querystring with ';' as separator

### DIFF
--- a/lib/OicServer.js
+++ b/lib/OicServer.js
@@ -140,7 +140,7 @@ _.extend( devicePrototype, {
 			if ( flag & iotivity.OCEntityHandlerFlag.OC_REQUEST_FLAG ) {
 
 				if ( request.query ) {
-					oicReq.queryOptions = querystring.parse( request.query );
+					oicReq.queryOptions = querystring.parse( request.query, ";" );
 				}
 
 				var len = request.rcvdVendorSpecificHeaderOptions.length;


### PR DESCRIPTION
The querystring received from iotivity contains the `;` as separator,
so use `;` as separator while parsing the querystring into a collection
of key and value pairs.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>