### PR TITLE
Increase timeout

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -32,7 +32,7 @@ function formatRuntime( runtime ) {
 
 QUnit.load();
 QUnit.config.requireExpects = true;
-QUnit.config.testTimeout = 30000;
+QUnit.config.testTimeout = 90000;
 QUnit.config.callbacks.moduleStart.push( function( status ) {
 
 	// Parameters: status: { name, tests }


### PR DESCRIPTION
- There are a lot of tests are failed due to timeout when run the test on Galileo
  with build#190, after increase timeout, these tests are 100% passed.

Signed-off-by: Hongjuan Wang <hongjuan.wang@intel.com>