### PR TITLE
OCDeviceInfo: Fix memory leaks in OCSetDeviceInfo

### DIFF
--- a/src/functions/simple.cc
+++ b/src/functions/simple.cc
@@ -66,7 +66,7 @@ NAN_METHOD(bind_OCSetDeviceInfo) {
 
   OCStackResult result = OCSetDeviceInfo(deviceInfo);
 
-  free(deviceInfo.deviceName);
+  c_OCDeviceInfoFreeMembers(&deviceInfo);
 
   info.GetReturnValue().Set(Nan::New(result));
 }


### PR DESCRIPTION
Fix leaks in OCSetDeviceInfo by freeing all the members
of OCDeviceInfo.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>