### PR TITLE
OCPlatformInfo: Fix a leak in platformInfo

### DIFF
--- a/src/structures/oc-platform-info.cc
+++ b/src/structures/oc-platform-info.cc
@@ -62,8 +62,6 @@ bool c_OCPlatformInfo(Local<Object> platformInfo, OCPlatformInfo *info) {
 
   VALIDATE_AND_ASSIGN_STRING(&local, platformID, platformInfo,
                              c_OCPlatformInfoFreeMembers, false);
-  VALIDATE_AND_ASSIGN_STRING(&local, platformID, platformInfo,
-                             c_OCPlatformInfoFreeMembers, false);
   VALIDATE_AND_ASSIGN_STRING(&local, manufacturerName, platformInfo,
                              c_OCPlatformInfoFreeMembers, false);
   VALIDATE_AND_ASSIGN_STRING(&local, manufacturerUrl, platformInfo,


### PR DESCRIPTION
Fix a leak in platformInfo by removing duplicate assignment
of platformID.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>