### PR TITLE
Build: Set the correct CFLAGS in iotivity-node

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,8 +7,7 @@
 			'<!@(echo "-I$(pwd)/deps/iotivity/include/iotivity/resource/csdk/stack/include")',
 			'<!@(echo "-I$(pwd)/deps/iotivity/include/iotivity/resource/c_common/ocrandom/include")',
 			'<!@(echo "-I$(pwd)/deps/iotivity/include/iotivity/resource/c_common")',
-			'-DROUTING_EP',
-			'-DTCP_ADAPTER'
+			'-DROUTING_EP'
 		]
 	},
 

--- a/octbstack.pc.in
+++ b/octbstack.pc.in
@@ -6,4 +6,4 @@ Name: liboctbstack
 Description: iotivity CSDK
 Version: 1.1.1-RC2
 Libs: -L${libdir} -Wl,-rpath ${libdir} -loctbstack @PLATFORM_LIBS@
-Cflags: -I${includedir}/@OCTB_STACK_INCLUDEDIR@ -I${includedir}/@OCTB_RANDOM_INCLUDEDIR@ -I${includedir}/@OCTB_CCOMMON_INCLUDEDIR@ -DTCP_ADAPTER -DROUTING_EP
+Cflags: -I${includedir}/@OCTB_STACK_INCLUDEDIR@ -I${includedir}/@OCTB_RANDOM_INCLUDEDIR@ -I${includedir}/@OCTB_CCOMMON_INCLUDEDIR@ -DROUTING_EP


### PR DESCRIPTION
Build flag TCP_ADAPTER is not set by default in iotivity,
so removing it from the CFLAGS in iotivity-node to prevent
an unexpected behavior.

Signed-off-by: Sudarsana Nagineni sudarsana.nagineni@intel.com
