### PR TITLE
Add arm arch to linux

### DIFF
--- a/build-scripts/build-csdk.js
+++ b/build-scripts/build-csdk.js
@@ -57,7 +57,7 @@ var archMap = {
 	"linux": {
 			"x64": "x86_64",
 			"arm": "arm"
-		 }
+			}
 };
 
 // Determine the CSDK revision

--- a/build-scripts/build-csdk.js
+++ b/build-scripts/build-csdk.js
@@ -54,7 +54,10 @@ var binariesSource, installWinHeaders, architecture, tinycborPath;
 // This can get complicated ...
 var archMap = {
 	"win32": { "x64": "amd64" },
-	"linux": { "x64": "x86_64" }
+	"linux": {
+			"x64": "x86_64",
+			"arm": "arm"
+		 }
 };
 
 // Determine the CSDK revision


### PR DESCRIPTION
@gabrielschulhof I'm not sure whether this is the right repo to send PRs to (is iotivity-node maintained here on github or in gerrit.iotivity.org?).

At least I added the arm architecture to the archMap since otherwise architecture will be empty and TARGET_ARCH will not be set.

Other architectures might need to be added as well, but I needed this for my raspberry docker image at https://github.com/wind-rider/raspberry-pi-iotivity-node.