### PR TITLE
secure: enable resource secure endpoint

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -27,7 +27,7 @@
 				# When building internally, we use pre-defined CFLAGS/LIBS, trusting that the CSDK
 				# will be built successfully
 
-				"defines": [ "ROUTING_EP" ],
+				"defines": [ "ROUTING_EP", "SECURED=1" ],
 				"include_dirs+": [ '<@(internalOCTBStack_include_dirs)' ],
 				"conditions": [
 

--- a/lib/payload.js
+++ b/lib/payload.js
@@ -48,7 +48,7 @@ var payloadUtils = {
 			href: init.resourcePath,
 			p: {
 				bm: ( payloadUtils.initToBitmap( init ) &
-					( ~csdk.OCResourceProperty.OC_SECURE ) ),
+					( ~(csdk.OCResourceProperty.OC_SECURE | csdk.OCResourceProperty.OC_NONSECURE) ) ),
 				sec: !!( init.secure )
 			}
 		} );
@@ -64,10 +64,10 @@ var payloadUtils = {
 			isNonEmptyStringArray( init.interfaces ) );
 	},
 	initToBitmap: function( init ) {
-		return ( 0 |
+		return ( csdk.OCResourceProperty.OC_SECURE |
 			( init.discoverable ? csdk.OCResourceProperty.OC_DISCOVERABLE : 0 ) |
 			( init.observable ? csdk.OCResourceProperty.OC_OBSERVABLE : 0 ) |
-			( init.secure ? csdk.OCResourceProperty.OC_SECURE : 0 ) |
+			( init.secure ? 0 : csdk.OCResourceProperty.OC_NONSECURE ) |
 			( init.slow ? csdk.OCResourceProperty.OC_SLOW : 0 ) |
 			( init.active ? csdk.OCResourceProperty.OC_ACTIVE : 0 ) );
 	},

--- a/src/enums.cc.in
+++ b/src/enums.cc.in
@@ -18,6 +18,11 @@
 
 #include "enums.h"
 
+// Symbol '__WITH_DTLS__' or '__WITH_TLS__' were defined while SECURED=1 in the SConscript
+#if SECURED==1
+#define __WITH_DTLS__ 1
+#endif
+
 extern "C" {
 #include <ocstack.h>
 }


### PR DESCRIPTION
Current iotivity-node always creates nonsecure `coap://` endpoints regardless the value set in the `secure` property during the resource registration; this commit is to enable the `coaps://` `secure` endpoints if the secure property is set to `true`.

Fix #145 
Signed-off-by: Tonny Tzeng tonny.tzeng@intel.com