### PR TITLE
install: Port post install task for Linux libs

### DIFF
--- a/build-scripts/postinstall.js
+++ b/build-scripts/postinstall.js
@@ -15,6 +15,7 @@
 var path = require( "path" );
 var fs = require( "fs" );
 var shelljs = require( "shelljs" );
+var os = require( "os" );
 var repoPaths = require( "./helpers/repo-paths" );
 var addonAbsoluteName = require( "bindings" )( { bindings: "iotivity", path: true } );
 var addonAbsolutePath = path.dirname( addonAbsoluteName );
@@ -44,11 +45,15 @@ if ( !isDependency ) {
 
 // Purge intermediate build files but leave the addon where it is
 shelljs.mv( addonAbsoluteName, repoPaths.root );
-shelljs.mv( path.join( addonAbsolutePath, "octbstack.dll" ), repoPaths.root );
+if ( os.platform() === "win32" ) {
+	shelljs.mv( path.join( addonAbsolutePath, "octbstack.dll" ), repoPaths.root );
+}
 shelljs.rm( "-rf", path.join( repoPaths.root, "build" ) );
 shelljs.mkdir( "-p", addonAbsolutePath );
 shelljs.mv( path.join( repoPaths.root, addonName ), addonAbsolutePath );
-shelljs.mv( path.join( repoPaths.root, "octbstack.dll" ), addonAbsolutePath );
+if ( os.platform() === "win32" ) {
+	shelljs.mv( path.join( repoPaths.root, "octbstack.dll" ), addonAbsolutePath );
+}
 
 // Purge any and all files not needed after building
 shelljs.rm( "-rf",


### PR DESCRIPTION
While trying iot-rest-api-server,
I observed this issue on npm install:

  > node build-scripts/postinstall.js
  mv: no such file or directory: .../iotivity-node/build/Release/octbstack.dll

This can reproduced on iotivity node using:

  NODE_ENV=production npm install

So libraries names depends on os.platform

Signed-off-by: Philippe Coval <philippe.coval@osg.samsung.com>