### PR TITLE
Update nan version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash.remove": "^4.0.0",
     "lodash.uniq": "^4.0.0",
     "lodash.without": "^4.0.0",
-    "nan": "^2.1.0",
+    "nan": "^2.8.0",
     "osenv": "^0.1.3",
     "sha.js": "^2.4.4",
     "shelljs": "^0.5.3"


### PR DESCRIPTION
The recent commits which change dependencies of Nan::ForceSet() to Nan::DefineOwnProperty() require an update to Nan dependencies otherwise an error of `error: no member named 'DefineOwnProperty' in namespace 'Nan'` is thrown.